### PR TITLE
Updating the version of windows data science VM

### DIFF
--- a/ArmTemplates/dsvm_arm.json
+++ b/ArmTemplates/dsvm_arm.json
@@ -33,7 +33,7 @@
         "imagePublisher": "microsoft-ads",
         "imageOffer": "windows-data-science-vm",
         "sku": "windows2016",
-        "version": "03.25.19",
+        "version": "19.08.09",
         "OSDiskName": "osdiskforwindowssimple",
         "nicName": "[parameters('vmName')]",
         "addressPrefix": "10.0.0.0/16",


### PR DESCRIPTION
Updating the version of windows data science VM from "03.25.19" to "19.08.09" as the version is now updated. Details of the latest version list is in this MSDN [thread ](https://social.msdn.microsoft.com/Forums/en-US/d578b1ab-b4b5-4529-8fa2-723cdb2f81a4/cannot-deploy-machine-learning-example-on-azure?forum=MachineLearning)for reference.